### PR TITLE
Update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,9 @@ src
 tsconfig.json
 tslint.json
 dist/**/*.test.*
+.idea
+yarn-error.log
+.travis.yml
+.eslintrc.json
+README.md
+build-docs.sh


### PR DESCRIPTION
Noticed that the publish tarball was bloated, this should help for the next release.