### PR TITLE
Bump for release (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demux-postgres",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Demux-js Action Handler implementation for Postgres databases",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
1.0.0 was taken up by a bad accidental release some time ago, so we're skipping that major version entirely. This has the added unintentional side-effect of syncing up major versions with `demux` and `demux-eos` (possibly just temporarily).