### PR TITLE
Use absolute paths for QueryFiles

### DIFF
--- a/src/MassiveActionHandler.test.ts
+++ b/src/MassiveActionHandler.test.ts
@@ -1,5 +1,6 @@
 import Docker from "dockerode"
 import massive from "massive"
+import * as path from "path"
 import { Migration } from "./Migration"
 import { MigrationRunner } from "./MigrationRunner"
 import blockchains from "./testHelpers/blockchains"
@@ -16,6 +17,8 @@ const dbUser = "docker"
 const dbPass = "docker"
 
 jest.setTimeout(30000)
+
+const baseDir = path.join(path.resolve("./"), "src")
 
 describe("TestMassiveActionHandler", () => {
   let runner: MigrationRunner
@@ -50,8 +53,8 @@ describe("TestMassiveActionHandler", () => {
   beforeEach(async () => {
     schemaName = "s" + Math.random().toString(36).substring(7)
     migrations = [
-      new Migration("createTodoTable", schemaName, "testHelpers/migration1.sql"),
-      new Migration("createTaskTable", schemaName, "testHelpers/migration2.sql"),
+      new Migration("createTodoTable", schemaName, path.join(baseDir, "testHelpers/migration1.sql")),
+      new Migration("createTaskTable", schemaName, path.join(baseDir, "testHelpers/migration2.sql")),
     ]
     runner = new MigrationRunner(
       massiveInstance.instance,

--- a/src/Migration.test.ts
+++ b/src/Migration.test.ts
@@ -1,17 +1,20 @@
-import { Migration } from "./Migration"
+import * as path from "path"
 import { QueryFile } from "pg-promise"
+import { Migration } from "./Migration"
 
 class TestMigration extends Migration {
   get _downQueryFile(): QueryFile | null { return this.downQueryFile }
 }
+
+const baseDir = path.join(path.resolve("./"), "src")
 
 describe("Migration", () => {
   it("instantiates a Migration instance", () => {
     const migration = new TestMigration(
       "test",
       "public",
-      "testHelpers/migration1.sql",
-      "testHelpers/migration2.sql",
+      path.join(baseDir, "testHelpers/migration1.sql"),
+      path.join(baseDir, "testHelpers/migration2.sql"),
     )
     expect(migration).toBeTruthy()
     expect(migration._downQueryFile).not.toBe(null)

--- a/src/Migration.ts
+++ b/src/Migration.ts
@@ -27,9 +27,7 @@ export class Migration {
     await pgp.none(this.downQueryFile)
   }
 
-  private loadQueryFile(file: string) {
-    let fullPath: string
-    fullPath = path.join(__dirname, file)
+  private loadQueryFile(filepath: string) {
     const options = {
       minify: true,
       noWarnings: true,
@@ -37,7 +35,7 @@ export class Migration {
         schema: this.schema,
       },
     }
-    const qf = new QueryFile(fullPath, options)
+    const qf = new QueryFile(filepath, options)
     if (qf.error) {
       throw qf.error
     }

--- a/src/Migration.ts
+++ b/src/Migration.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import { IDatabase, QueryFile } from "pg-promise"
 
 export class Migration {

--- a/src/MigrationRunner.test.ts
+++ b/src/MigrationRunner.test.ts
@@ -1,5 +1,6 @@
 import Docker from "dockerode"
 import massive from "massive"
+import * as path from "path"
 import { IDatabase } from "pg-promise"
 import { Migration } from "./Migration"
 import { MigrationRunner } from "./MigrationRunner"
@@ -10,6 +11,8 @@ const postgresImageName = "postgres:10.4"
 const dbName = "migrationrunnertest"
 const dbUser = "docker"
 const dbPass = "docker"
+
+const baseDir = path.join(path.resolve("./"), "src")
 
 class TestMigrationRunner extends MigrationRunner {
   public async _checkOrCreateSchema() { await this.checkOrCreateSchema() }
@@ -137,9 +140,9 @@ describe("MigrationRunner", () => {
   beforeEach(async (done) => {
     schemaName = randomSchemaName()
     migrations = [
-      new Migration("createTodoTable", schemaName, "testHelpers/migration1.sql"),
-      new Migration("createTaskTable", schemaName, "testHelpers/migration2.sql"),
-      new Migration("createAssigneeTable", schemaName, "testHelpers/migration3.sql"),
+      new Migration("createTodoTable", schemaName, path.join(baseDir, "testHelpers/migration1.sql")),
+      new Migration("createTaskTable", schemaName, path.join(baseDir, "testHelpers/migration2.sql")),
+      new Migration("createAssigneeTable", schemaName, path.join(baseDir, "testHelpers/migration3.sql")),
     ]
     runner = new TestMigrationRunner(
       massiveInstance.instance,
@@ -214,7 +217,7 @@ describe("MigrationRunner", () => {
       new Migration(
         "mymigration",
         schemaName,
-        "testHelpers/migration1.sql",
+        path.join(baseDir, "testHelpers/migration1.sql"),
       ),
     )
     const error = new Error(

--- a/src/MigrationRunner.ts
+++ b/src/MigrationRunner.ts
@@ -1,5 +1,6 @@
 import { IDatabase } from "pg-promise"
 import { Migration } from "./Migration"
+import * as path from "path"
 
 export class MigrationRunner {
   private isSetUp: boolean = false
@@ -70,7 +71,7 @@ export class MigrationRunner {
   }
 
   protected async installCyanAudit() {
-    const cyanaudit = new Migration("", "", "cyanaudit/cyanaudit--2.2.0.sql")
+    const cyanaudit = new Migration("", "", path.join(__dirname, "cyanaudit/cyanaudit--2.2.0.sql"))
     await cyanaudit.up(this.pgp)
     await this.refreshCyanAudit()
   }


### PR DESCRIPTION
Resolves #22.

Since `__dirname` always uses the path from where the code that called it lives, we can't use it dynamically, and must pass absolute paths for the QueryFile. It will now be the responsibility of the caller to resolve a portable absolute path.