### PR TITLE
Fixed syntax for CommonJS module exporting/importing.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-declare function require(name:string):any;
-const massive = require('massive');
+declare function require(name:string):any
+const massive = require('massive')
 export { massive }
 export { MassiveActionHandler } from './MassiveActionHandler'
 export { Migration } from './Migration'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-declare function require(name:string):any
-const massive = require('massive')
+declare function require(name: string): any
+import massive = require('massive')
 export { massive }
 export { MassiveActionHandler } from './MassiveActionHandler'
 export { Migration } from './Migration'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
+declare function require(name:string):any;
+const massive = require('massive');
+export { massive }
 export { MassiveActionHandler } from './MassiveActionHandler'
 export { Migration } from './Migration'
 export { MigrationRunner } from './MigrationRunner'
 export { MigrationSequence, MassiveActionHandlerOptions } from './interfaces'
-export { default as massive } from 'massive'


### PR DESCRIPTION
`massive` is written in CommonJS and not Typescript. Exporting it like `export {default as massive} from 'massive'` would export massive with `undefined` value from `demux-js-postgres`.