### PR TITLE
Fix cyanaudit migration in PostgreSQL 12

### DIFF
--- a/src/cyanaudit/cyanaudit--2.2.0.sql
+++ b/src/cyanaudit/cyanaudit--2.2.0.sql
@@ -1147,7 +1147,7 @@ begin
 
     my_constraint_name := 'partition_range_chk';
 
-     select cn.consrc
+     select pg_get_constraintdef(cn.oid) as consrc
        into my_constraint_src
        from pg_constraint cn
        join pg_class c


### PR DESCRIPTION
https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=96b00c433cd615144a34ff1a79d691d8b297120d

In PostgreSQL 12, `pg_constraint.consrc` column is removed, so it causes an error during cyanaudit migration.